### PR TITLE
Add Support for dag.get, dag.put

### DIFF
--- a/include/ipfs/client.h
+++ b/include/ipfs/client.h
@@ -229,6 +229,24 @@ class Client {
       /** [out] Retrieved information about the block. */
       Json* stat);
 
+  /** Store a MerkleDAG node, new API
+   *
+   * Implements
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/DAG.md#dagput.
+   *
+   * An example usage:
+   * @snippet dag.cc ipfs::Client::DagPut
+   *
+   * @throw std::exception if any error occurs
+   *
+   * @since version 0.4.0 */
+  void DagPut(
+      /** [in] Node to store. */
+      const Json& dag,
+      /** [out] Stored node. Should be the same as the provided `object` plus
+       * the stored object's multihash id. */
+      Json* dag_stored);
+
   /** Get a MerkleDAG node, new API
    *
    * Implements

--- a/include/ipfs/client.h
+++ b/include/ipfs/client.h
@@ -229,6 +229,25 @@ class Client {
       /** [out] Retrieved information about the block. */
       Json* stat);
 
+  /** Get a MerkleDAG node, new API
+   *
+   * Implements
+   * https://github.com/ipfs/interface-ipfs-core/tree/master/SPEC/DAG.md#dagget.
+   *
+   * An example usage:
+   * @snippet dag.cc ipfs::Client::DagGet
+   *
+   * @throw std::exception if any error occurs
+   *
+   * @since version 0.4.0 */
+  void DagGet(
+      /** [in] Id (multihash) of the MerkleDAG node to fetch. */
+      const std::string& cid,
+      /** [out] Retrieved MerkleDAG node. For example:
+       * {"Data": "abc", "Links": [{"Name": "link1", "Hash": "...", "Size": 8}]}
+       */
+      Json* object);
+
   /** Get a file from IPFS.
    *
    * Implements

--- a/src/client.cc
+++ b/src/client.cc
@@ -157,6 +157,11 @@ void Client::BlockStat(const std::string& block_id, Json* stat) {
   FetchAndParseJson(MakeUrl("block/stat", {{"arg", block_id}}), stat);
 }
 
+void Client::DagGet(const std::string& cid, Json* value) {
+  FetchAndParseJson(MakeUrl("dag/get", {{"arg", cid}}), value);
+  // http_->Fetch(MakeUrl("dag/get", {{"arg", cid}}), {}, value);
+}
+
 void Client::FilesGet(const std::string& path, std::iostream* response) {
   http_->Fetch(MakeUrl("cat", {{"arg", path}}), {}, response);
 }

--- a/src/client.cc
+++ b/src/client.cc
@@ -157,6 +157,13 @@ void Client::BlockStat(const std::string& block_id, Json* stat) {
   FetchAndParseJson(MakeUrl("block/stat", {{"arg", block_id}}), stat);
 }
 
+void Client::DagPut(const Json& dag, Json* dag_stored) {
+  FetchAndParseJson(
+      MakeUrl("dag/put", {{"inputenc", "json"}}),
+      {{"node.json", http::FileUpload::Type::kFileContents, dag.dump()}},
+      dag_stored);
+}
+
 void Client::DagGet(const std::string& cid, Json* value) {
   FetchAndParseJson(MakeUrl("dag/get", {{"arg", cid}}), value);
   // http_->Fetch(MakeUrl("dag/get", {{"arg", cid}}), {}, value);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TESTS
   block
   config
+  dag
   dht
   files
   generic

--- a/test/dag.cc
+++ b/test/dag.cc
@@ -28,9 +28,8 @@ int main(int, char**) {
   try {
     ipfs::Client client("localhost", 5001);
 
-#if 0
     /** [ipfs::Client::DagPut] */
-    ipfs::Json object_to_store = R"(
+    ipfs::Json dag_to_store = R"(
       {
           "Data": "another",
           "Links": [ {
@@ -40,12 +39,12 @@ int main(int, char**) {
           } ]
       }
     )"_json;
-    ipfs::Json object_stored;
-    client.DagPut(object_to_store, &object_stored);
+    ipfs::Json dag_stored;
+    client.DagPut(dag_to_store, &dag_stored);
     std::cout << "Dag to store:" << std::endl
-              << object_to_store.dump(2) << std::endl;
-    std::cout << "Stored object:" << std::endl
-              << object_stored.dump(2) << std::endl;
+              << dag_to_store.dump(2) << std::endl;
+    std::cout << "Stored dag:" << std::endl
+              << dag_stored.dump(2) << std::endl;
     /* An example output:
     Dag to store:
     {
@@ -58,28 +57,22 @@ int main(int, char**) {
         }
       ]
     }
-    Stored object:
+    Stored dag:
     {
-      "Hash": "QmZZmY4KCu9r3e7M2Pcn46Fc5qbn6NpzaAGaYb22kbfTqm",
-      "Links": [
-        {
-          "Hash": "QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V",
-          "Name": "some link",
-          "Size": 8
-        }
-      ]
+      "Cid": {
+        "/": "bafyreic25pekmrs3pezhzlnpztcnlqjgulknd52wk3tdfghnjjrq7dugpq"
+      }
     }
     */
     /** [ipfs::Client::DagPut] */
-    ipfs::test::check_if_properties_exist("client.DagPut()", object_stored,
-                                          {"Hash", "Links"});
+    ipfs::test::check_if_properties_exist("client.DagPut()", dag_stored,
+                                          {"Cid"});
 
-#endif
 
     /** [ipfs::Client::DagGet] */
-    ipfs::Json object;
-    client.DagGet("QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n", &object);
-    std::cout << "Dag: " << std::endl << object.dump(2) << std::endl;
+    ipfs::Json dag;
+    client.DagGet("bafyreic25pekmrs3pezhzlnpztcnlqjgulknd52wk3tdfghnjjrq7dugpq", &dag);
+    std::cout << "Dag: " << std::endl << dag.dump(2) << std::endl;
     /* An example output:
     Dag:
     {

--- a/test/dag.cc
+++ b/test/dag.cc
@@ -1,0 +1,153 @@
+/* Copyright (c) 2016-2016, Vasil Dimov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include <ipfs/client.h>
+#include <ipfs/test/utils.h>
+
+int main(int, char**) {
+  try {
+    ipfs::Client client("localhost", 5001);
+
+#if 0
+    /** [ipfs::Client::DagPut] */
+    ipfs::Json object_to_store = R"(
+      {
+          "Data": "another",
+          "Links": [ {
+              "Name": "some link",
+              "Hash": "QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V",
+              "Size": 8
+          } ]
+      }
+    )"_json;
+    ipfs::Json object_stored;
+    client.DagPut(object_to_store, &object_stored);
+    std::cout << "Dag to store:" << std::endl
+              << object_to_store.dump(2) << std::endl;
+    std::cout << "Stored object:" << std::endl
+              << object_stored.dump(2) << std::endl;
+    /* An example output:
+    Dag to store:
+    {
+      "Data": "another",
+      "Links": [
+        {
+          "Hash": "QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V",
+          "Name": "some link",
+          "Size": 8
+        }
+      ]
+    }
+    Stored object:
+    {
+      "Hash": "QmZZmY4KCu9r3e7M2Pcn46Fc5qbn6NpzaAGaYb22kbfTqm",
+      "Links": [
+        {
+          "Hash": "QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V",
+          "Name": "some link",
+          "Size": 8
+        }
+      ]
+    }
+    */
+    /** [ipfs::Client::DagPut] */
+    ipfs::test::check_if_properties_exist("client.DagPut()", object_stored,
+                                          {"Hash", "Links"});
+
+#endif
+
+    /** [ipfs::Client::DagGet] */
+    ipfs::Json object;
+    client.DagGet("QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n", &object);
+    std::cout << "Dag: " << std::endl << object.dump(2) << std::endl;
+    /* An example output:
+    Dag:
+    {
+      "Data": "another",
+      "Links": [ {
+        "Name": "some link",
+        "Hash": "QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V",
+        "Size": 8
+      } ]
+    }
+    */
+    /** [ipfs::Client::DagGet] */
+
+
+#if 0
+    /** [ipfs::Client::DagTree] */
+    ipfs::Json stat;
+    client.DagTree("QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG", &stat);
+    std::cout << "Dag data size: " << stat["DataSize"] << std::endl;
+    /* An example output:
+    Dag data size: 2
+    */
+    /** [ipfs::Client::DagTree] */
+    ipfs::test::check_if_properties_exist(
+        "client.DagTree()", stat, {"BlockSize", "CumulativeSize", "DataSize",
+                                      "Hash", "LinksSize", "NumLinks"});
+
+    {
+      /** [ipfs::Client::DagPatchAddLink] */
+      /* Create a new node, upload two files and link them to the node. */
+
+      std::string orig_id;
+      client.DagNew(&orig_id);
+
+      ipfs::Json added_files;
+      client.FilesAdd(
+          {{"file1.txt", ipfs::http::FileUpload::Type::kFileContents, "f1f1"},
+           {"file2.txt", ipfs::http::FileUpload::Type::kFileContents, "f2f2"}},
+          &added_files);
+
+      std::string new_id;
+      client.DagPatchAddLink(orig_id, "link to file1.txt",
+                                added_files[0]["hash"], &new_id);
+
+      ipfs::Json new_object;
+      client.DagGet(new_id, &new_object);
+      std::cout << "Added a link to " << orig_id << "." << std::endl
+                << "New object " << new_id << ":" << std::endl
+                << new_object.dump(2) << std::endl;
+      /* An example output:
+      Added a link to QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n.
+      New object QmRgn5ZeLiPRwQHqSbMLUZ2gkyLbJiaxVEx3LrDCqqaCAb:
+      {
+        "Data": "",
+        "Links": [
+          {
+            "Hash": "QmNYaS23te5Rja36U94JoSTuMxJZmBEnHN8KEcjR6rGRGn",
+            "Name": "link to file1.txt",
+            "Size": 12
+          }
+        ]
+      }
+      */
+#endif
+  } catch (const std::exception& e) {
+    std::cerr << e.what() << std::endl;
+    return 1;
+  }
+
+  return 0;
+}

--- a/test/dag.cc
+++ b/test/dag.cc
@@ -31,11 +31,12 @@ int main(int, char**) {
     /** [ipfs::Client::DagPut] */
     ipfs::Json dag_to_store = R"(
       {
-          "Data": "another",
-          "Links": [ {
-              "Name": "some link",
-              "Hash": "QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V",
-              "Size": 8
+          "thing": "stuff",
+          "MoreData": "important",
+          "Stinks": [ {
+              "Name": "old sock",
+              "Splash": "QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V",
+              "Spize": 42
           } ]
       }
     )"_json;
@@ -48,19 +49,20 @@ int main(int, char**) {
     /* An example output:
     Dag to store:
     {
-      "Data": "another",
-      "Links": [
+      "thing": "stuff",
+      "MoreData": "important",
+      "Stinks": [
         {
           "Hash": "QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V",
-          "Name": "some link",
-          "Size": 8
+          "Name": "old sock",
+          "Size": 42
         }
       ]
     }
     Stored dag:
     {
       "Cid": {
-        "/": "bafyreic25pekmrs3pezhzlnpztcnlqjgulknd52wk3tdfghnjjrq7dugpq"
+        "/": "bafyreie3ybajzu6qlfjxpq4mwe62klirtc7yxmpuzclc22e6ifremzlrmq"
       }
     }
     */
@@ -71,17 +73,20 @@ int main(int, char**) {
 
     /** [ipfs::Client::DagGet] */
     ipfs::Json dag;
-    client.DagGet("bafyreic25pekmrs3pezhzlnpztcnlqjgulknd52wk3tdfghnjjrq7dugpq", &dag);
+    client.DagGet("bafyreie3ybajzu6qlfjxpq4mwe62klirtc7yxmpuzclc22e6ifremzlrmq", &dag);
     std::cout << "Dag: " << std::endl << dag.dump(2) << std::endl;
     /* An example output:
     Dag:
     {
-      "Data": "another",
-      "Links": [ {
-        "Name": "some link",
-        "Hash": "QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V",
-        "Size": 8
-      } ]
+      "MoreData": "important",
+      "Stinks": [
+        {
+          "Hash": "QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V",
+          "Name": "old sock",
+          "Size": 42
+        }
+      ],
+      "thing": "stuff"
     }
     */
     /** [ipfs::Client::DagGet] */

--- a/test/dag.cc
+++ b/test/dag.cc
@@ -91,57 +91,6 @@ int main(int, char**) {
     */
     /** [ipfs::Client::DagGet] */
 
-
-#if 0
-    /** [ipfs::Client::DagTree] */
-    ipfs::Json stat;
-    client.DagTree("QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG", &stat);
-    std::cout << "Dag data size: " << stat["DataSize"] << std::endl;
-    /* An example output:
-    Dag data size: 2
-    */
-    /** [ipfs::Client::DagTree] */
-    ipfs::test::check_if_properties_exist(
-        "client.DagTree()", stat, {"BlockSize", "CumulativeSize", "DataSize",
-                                      "Hash", "LinksSize", "NumLinks"});
-
-    {
-      /** [ipfs::Client::DagPatchAddLink] */
-      /* Create a new node, upload two files and link them to the node. */
-
-      std::string orig_id;
-      client.DagNew(&orig_id);
-
-      ipfs::Json added_files;
-      client.FilesAdd(
-          {{"file1.txt", ipfs::http::FileUpload::Type::kFileContents, "f1f1"},
-           {"file2.txt", ipfs::http::FileUpload::Type::kFileContents, "f2f2"}},
-          &added_files);
-
-      std::string new_id;
-      client.DagPatchAddLink(orig_id, "link to file1.txt",
-                                added_files[0]["hash"], &new_id);
-
-      ipfs::Json new_object;
-      client.DagGet(new_id, &new_object);
-      std::cout << "Added a link to " << orig_id << "." << std::endl
-                << "New object " << new_id << ":" << std::endl
-                << new_object.dump(2) << std::endl;
-      /* An example output:
-      Added a link to QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n.
-      New object QmRgn5ZeLiPRwQHqSbMLUZ2gkyLbJiaxVEx3LrDCqqaCAb:
-      {
-        "Data": "",
-        "Links": [
-          {
-            "Hash": "QmNYaS23te5Rja36U94JoSTuMxJZmBEnHN8KEcjR6rGRGn",
-            "Name": "link to file1.txt",
-            "Size": 12
-          }
-        ]
-      }
-      */
-#endif
   } catch (const std::exception& e) {
     std::cerr << e.what() << std::endl;
     return 1;


### PR DESCRIPTION
This provides support for a minimalist implementation of `dag.get`, `dag.put`.  DAG's replace the older `object` API, and allow pretty much any kind of json data to be written. 

The API here is minimalist; it fails to implement any of the options/optional settings, mostly because I am not clear on what a good C++ API for the options should be. Ping me with suggestions, and I can update this or a later pull request.

This pull req does NOT depend on any of the other outstanding pull reqs.