### PR TITLE
Provide an explicit copy constructor

### DIFF
--- a/include/ipfs/client.h
+++ b/include/ipfs/client.h
@@ -57,6 +57,10 @@ class Client {
       /** [in] Port to connect to. */
       long port);
 
+  Client(
+      /** [in] Other client connection to be copied */
+      const Client&);
+
   /** Destructor.
    * @since version 0.1.0 */
   ~Client();

--- a/src/client.cc
+++ b/src/client.cc
@@ -35,6 +35,11 @@ Client::Client(const std::string& host, long port)
   http_ = new http::TransportCurl();
 }
 
+Client::Client(const Client& other)
+    : url_prefix_(other.url_prefix_) {
+  http_ = new http::TransportCurl();
+}
+
 Client::~Client() { delete http_; }
 
 void Client::Id(Json* id) { FetchAndParseJson(MakeUrl("id"), id); }


### PR DESCRIPTION
This fixes issue vasild/cpp-ipfs-api#13 "Client crash when copy."