### PR TITLE
Update Modern C++ Json location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ include_directories(${CURL_INCLUDE_DIRS})
 find_path(JSON_FOR_MODERN_CXX_INCLUDE_DIR NAMES nlohmann/json.hpp)
 mark_as_advanced(JSON_FOR_MODERN_CXX_INCLUDE_DIR)
 if(NOT JSON_FOR_MODERN_CXX_INCLUDE_DIR)
-  message(FATAL_ERROR "JSON for Modern C++ (nlohmann/json.hpp) not found. Go fetch it from https://github.com/nlohmann/json/blob/develop/src/json.hpp and tell CMake where it is: 'cmake -DJSON_FOR_MODERN_CXX_INCLUDE_DIR:PATH=/path/to/include' (assuming the file is in /path/to/include/nlohmann/json.hpp)")
+  message(FATAL_ERROR "JSON for Modern C++ (nlohmann/json.hpp) not found. Go fetch it from https://raw.githubusercontent.com/nlohmann/json/develop/include/nlohmann/json.hpp and tell CMake where it is: 'cmake -DJSON_FOR_MODERN_CXX_INCLUDE_DIR:PATH=/path/to/include' (assuming the file is in /path/to/include/nlohmann/json.hpp)")
 endif()
 include_directories(${JSON_FOR_MODERN_CXX_INCLUDE_DIR})
 


### PR DESCRIPTION
Update json.hpp location.

However I would appricate it, if this project is able to include this dependency automatically.

Like the Cmake fetch & embed:

https://github.com/nlohmann/json#embedded-fetchcontent


Like so:

```cmake

# Targets
set(IPFS_API_LIBNAME ipfs-http-client)

include_directories("include")

# To build and install a shared library: "cmake -DBUILD_SHARED_LIBS:BOOL=ON ..."
add_library(${IPFS_API_LIBNAME}
  src/client.cc
  src/http/transport-curl.cc
)

# Fetch "JSON for Modern C++"
include(FetchContent)

FetchContent_Declare(json
  GIT_REPOSITORY https://github.com/nlohmann/json.git
  GIT_TAG v3.9.1)

FetchContent_GetProperties(json)
if(NOT json_POPULATED)
  FetchContent_Populate(json)
  add_subdirectory(${json_SOURCE_DIR} ${json_BINARY_DIR} EXCLUDE_FROM_ALL)
endif()

set_target_properties(${IPFS_API_LIBNAME} PROPERTIES
  SOVERSION ${PROJECT_VERSION_MAJOR}
  VERSION ${PROJECT_VERSION}
)
target_link_libraries(${IPFS_API_LIBNAME} ${CURL_LIBRARIES} nlohmann_json::nlohmann_json)
```

Would be much better and easier for everybody 👍🏽 . I will create an alternative PR.
 