### PR TITLE
Add missing target_include_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,13 @@ add_library(${IPFS_API_LIBNAME}
   src/http/transport-curl.cc
 )
 
+# Be able to find to find client.h header file 
+#  (eg. when static linked, outside this project folder)
+target_include_directories(${IPFS_API_LIBNAME}
+  INTERFACE
+  ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
 # Fetch "JSON for Modern C++"
 include(FetchContent)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ add_library(${IPFS_API_LIBNAME}
   src/http/transport-curl.cc
 )
 
-# Be able to find to find client.h header file 
+# Be able to find the client.h header file 
 #  (eg. when static linked, outside this project folder)
 target_include_directories(${IPFS_API_LIBNAME}
   INTERFACE


### PR DESCRIPTION
Adding `target_include_directories` allowing users to set `ipfs-http-client` as target link librarty without needing to adapt their project's `target_include_directories`, since the library can set where to search for header files, via .. `target_include_directories`..