### PR TITLE
Expose nlohmann header files to the upper layer application.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ if(NOT DISABLE_INSTALL)
   install(TARGETS ${IPFS_API_LIBNAME} DESTINATION lib)
   install(FILES include/ipfs/client.h DESTINATION include/ipfs)
   install(FILES include/ipfs/http/transport.h DESTINATION include/ipfs/http)
+  install(FILES ${json_SOURCE_DIR}/include/nlohmann/json.hpp DESTINATION include/nlohmann)
+  install(FILES ${json_SOURCE_DIR}/include/nlohmann/json_fwd.hpp DESTINATION include/nlohmann)
 endif()
 # Tests, use "CTEST_OUTPUT_ON_FAILURE=1 make test" to see output from failed tests
 


### PR DESCRIPTION
Expose `nlohmann` header files to the upper layer application.

If we don't do this, and the upper-layer doesn't have `nlohmann` itself, then including `<ipfs/client.h>` cannot be processed.