### PR TITLE
Do explicit cast + check

### DIFF
--- a/src/http/transport-curl.cc
+++ b/src/http/transport-curl.cc
@@ -57,8 +57,11 @@ static size_t curl_cb_stream(
   std::iostream* response = static_cast<std::iostream*>(response_void);
 
   const size_t n = size * nmemb;
-
-  response->write(ptr, n);
+  if (static_cast<std::streamsize>(n) < 0) {
+    throw std::runtime_error("Buffer Size overflowing");
+  } else {
+    response->write(ptr, static_cast<std::streamsize>(n));
+  }
 
   return n;
 }


### PR DESCRIPTION
- Introducing the static cast in the first place
- Check static cast, throw runtime error