### PR TITLE
Add constructors and clean up moves/raw pointers

### DIFF
--- a/include/ipfs/client.h
+++ b/include/ipfs/client.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016-2022, The C++ IPFS client library developers
+/* Copyright (c) 2016-2023, The C++ IPFS client library developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -23,6 +23,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include <ipfs/http/transport.h>
 
 #include <iostream>
+#include <memory>
 #include <nlohmann/json.hpp>
 #include <string>
 #include <utility>
@@ -75,7 +76,7 @@ class Client {
   /** Move-constructor. */
   Client(
       /** [in,out] Other client connection to be moved. */
-      Client&&);
+      Client&&) noexcept;
 
   /** Copy assignment operator.
    * @return *this */
@@ -87,7 +88,7 @@ class Client {
    * @return *this */
   Client& operator=(
       /** [in,out] Other client connection to be moved. */
-      Client&&);
+      Client&&) noexcept;
 
   /** Destructor.
    * @since version 0.1.0 */
@@ -918,14 +919,10 @@ class Client {
   std::string url_prefix_;
 
   /** The underlying transport. */
-  http::Transport* http_;
+  std::unique_ptr<http::Transport> http_;
 
   /** Server-side time-out setting */
   std::string timeout_value_;
-
-  /** cURL debug mode, stored so this flag can be used in the copy
-   * constructor/assign operator */
-  bool curl_verbose_;
 };
 } /* namespace ipfs */
 

--- a/include/ipfs/http/transport-curl.h
+++ b/include/ipfs/http/transport-curl.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016-2022, The C++ IPFS client library developers
+/* Copyright (c) 2016-2023, The C++ IPFS client library developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -39,6 +39,27 @@ class TransportCurl : public Transport {
   TransportCurl(
       /** [in] Enable cURL verbose mode, useful for debugging. */
       bool curlVerbose);
+
+  /** Copy Constructor. */
+  TransportCurl(const TransportCurl& other);
+
+  /** Move-constructor. */
+  TransportCurl(TransportCurl&& other) noexcept;
+
+  /** Copy assignment operator.
+   * @return *this */
+  TransportCurl& operator=(
+      /** [in] Other TransportCurl object to be copied. */
+      const TransportCurl&);
+
+  /** Move assignment operator.
+   * @return *this */
+  TransportCurl& operator=(
+      /** [in,out] Other TransportCurl object to be moved. */
+      TransportCurl&&) noexcept;
+
+  /** Return a deep copy of this object. */
+  std::unique_ptr<Transport> Clone() const override;
 
   /** Destructor. */
   ~TransportCurl();
@@ -103,6 +124,9 @@ class TransportCurl : public Transport {
       /** [in,out] Response from the web server. */
       std::iostream* response);
 
+  /** Initialize cURL. */
+  void InitCurl();
+
   /** Atomic boolean for stopping a running fetch/perform, thread-safe */
   std::atomic<bool> keep_perform_running_;
 
@@ -116,7 +140,7 @@ class TransportCurl : public Transport {
   CURLM* multi_handle_;
 
   /** Flag for enabling CURL verbose mode, useful for debugging */
-  bool curl_verbose;
+  bool curl_verbose_;
 
   /** Flag to cause `UrlEncode()` to fail miserably. */
   bool url_encode_injected_failure = false;

--- a/include/ipfs/http/transport.h
+++ b/include/ipfs/http/transport.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016-2022, The C++ IPFS client library developers
+/* Copyright (c) 2016-2023, The C++ IPFS client library developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -21,6 +21,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #define IPFS_HTTP_TRANSPORT_H
 
 #include <iostream>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -52,6 +53,9 @@ struct FileUpload {
 /** Convenience interface for talking basic HTTP. */
 class Transport {
  public:
+  /** Return a deep copy of this object. */
+  virtual std::unique_ptr<Transport> Clone() const = 0;
+
   /** Destructor. */
   virtual inline ~Transport();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TESTS
   test_stats
   test_swarm
   test_threading
+  test_transport_curl
 )
 
 string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LOWER)

--- a/test/test_transport_curl.cc
+++ b/test/test_transport_curl.cc
@@ -1,0 +1,51 @@
+/* Copyright (c) 2016-2023, The C++ IPFS client library developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
+
+#include <ipfs/http/transport-curl.h>
+
+#include <cassert>
+#include <sstream>
+
+int main(int, char**) {
+  {
+    /* test normal fetch */
+    ipfs::http::TransportCurl transportCurl(false);
+    {
+      std::stringstream response;
+      transportCurl.Fetch("https://example.com/", {}, &response);
+      assert(!response.str().empty());
+    }
+    /* test move constructor */
+    {
+      ipfs::http::TransportCurl transportCurl2(std::move(transportCurl));
+      std::stringstream response;
+      transportCurl2.Fetch("https://example.com/", {}, &response);
+      assert(!response.str().empty());
+    }
+  }
+  /* test move assignment to other object */
+  {
+    ipfs::http::TransportCurl transportCurl(false);
+    ipfs::http::TransportCurl transportCurl2(false);
+    transportCurl2 = std::move(transportCurl);
+    std::stringstream response;
+    transportCurl2.Fetch("https://example.com/", {}, &response);
+    assert(!response.str().empty());
+  }
+}


### PR DESCRIPTION
- marked move constructors and move assignment operators `noexcept`
- wrapped `http::Transport*` in `std::unique_ptr`
- implemented missing copy constructor, move constructor, and move assignment operator for TransportCurl