### PR TITLE
Fix deprecated calls to curl (move to curl MIME API)

### DIFF
--- a/include/ipfs/http/transport-curl.h
+++ b/include/ipfs/http/transport-curl.h
@@ -146,8 +146,8 @@ class TransportCurl : public Transport {
   /** cURL multi handle. */
   CURLM* multi_handle_;
 
-  /** cURL mime part for post requests */
-  curl_mimepart* multipart_;
+  /** cURL mime structure for post requests */
+  curl_mime* multipart_;
 
   /** Flag for enabling CURL verbose mode, useful for debugging */
   bool curl_verbose_;

--- a/include/ipfs/http/transport-curl.h
+++ b/include/ipfs/http/transport-curl.h
@@ -146,6 +146,9 @@ class TransportCurl : public Transport {
   /** cURL multi handle. */
   CURLM* multi_handle_;
 
+  /** cURL mime part for post requests */
+  curl_mimepart* multipart_;
+
   /** Flag for enabling CURL verbose mode, useful for debugging */
   bool curl_verbose_;
 

--- a/src/http/transport-curl.cc
+++ b/src/http/transport-curl.cc
@@ -202,7 +202,7 @@ void TransportCurl::Fetch(const std::string& url,
           curl_mime_data(part, file.data.c_str(), file.data.length());
           curl_mime_filename(part, file.path.c_str());
           curl_mime_type(part,
-                         content_type);  // content type really needed here?
+                         content_type);
           break;
         case FileUpload::Type::kFileName:
           /* https://curl.se/libcurl/c/curl_formadd.html

--- a/src/http/transport-curl.cc
+++ b/src/http/transport-curl.cc
@@ -173,9 +173,6 @@ void TransportCurl::Fetch(const std::string& url,
   /* https://curl.se/libcurl/c/CURLOPT_POST.html */
   curl_easy_setopt(curl_, CURLOPT_POST, 1L);
 
-  // curl_httppost* form_parts = NULL;
-  // curl_httppost* form_parts_end = NULL;
-
   multipart_ = curl_mime_init(curl_);
 
   if (multipart_) {
@@ -187,15 +184,8 @@ void TransportCurl::Fetch(const std::string& url,
 
       switch (file.type) {
         case FileUpload::Type::kFileContents:
-          /* https://curl.se/libcurl/c/curl_formadd.html
-          * Deprecated:
-            curl_formadd(&form_parts, &form_parts_end,
-                      CURLFORM_COPYNAME, name.c_str(),
-                      CURLFORM_BUFFER, file.path.c_str(),
-                      CURLFORM_BUFFERPTR, file.data.c_str(),
-                      CURLFORM_BUFFERLENGTH, file.data.length(),
-                      CURLFORM_CONTENTTYPE, content_type, CURLFORM_END);*/
-          /* Add a part */
+          /* Add a part.
+           * https://curl.se/libcurl/c/curl_mime_addpart.html */
           part = curl_mime_addpart(multipart_);
           curl_mime_name(part, name.c_str());
           /* Memory source: */
@@ -204,14 +194,8 @@ void TransportCurl::Fetch(const std::string& url,
           curl_mime_type(part, content_type);
           break;
         case FileUpload::Type::kFileName:
-          /* https://curl.se/libcurl/c/curl_formadd.html
-          * Deprecated:
-            curl_formadd(&form_parts, &form_parts_end,
-                      CURLFORM_COPYNAME, name.c_str(),
-                      CURLFORM_FILENAME, file.path.c_str(),
-                      CURLFORM_FILE, file.data.c_str(),
-                      CURLFORM_CONTENTTYPE, content_type, CURLFORM_END);*/
-          /* Add a part */
+          /* Add a part.
+           * https://curl.se/libcurl/c/curl_mime_addpart.html */
           part = curl_mime_addpart(multipart_);
           curl_mime_name(part, name.c_str());
           /* File source: */
@@ -222,16 +206,6 @@ void TransportCurl::Fetch(const std::string& url,
           break;
       }
     }
-
-    /* Auto free the resources occupied by `form_parts`. */
-    /*std::unique_ptr<curl_httppost, void (*)(curl_httppost*)>
-       form_parts_deleter( form_parts, [](curl_httppost* d) {
-          curl_formfree(d);
-        });*/
-
-    /* https://curl.se/libcurl/c/CURLOPT_HTTPPOST.html
-    * Deprecated:
-    curl_easy_setopt(curl_, CURLOPT_HTTPPOST, form_parts);*/
 
     /* Set the form info
      * https://curl.se/libcurl/c/CURLOPT_MIMEPOST.html */

--- a/src/http/transport-curl.cc
+++ b/src/http/transport-curl.cc
@@ -178,11 +178,12 @@ void TransportCurl::Fetch(const std::string& url,
 
   multipart_ = curl_mime_init(curl_);
 
-  if (multipart) {
+  if (multipart_) {
     for (size_t i = 0; i < files.size(); ++i) {
       const FileUpload& file = files[i];
       const std::string name("file" + std::to_string(i));
       static const char* content_type = "application/octet-stream";
+      curl_mimepart* part;
 
       switch (file.type) {
         case FileUpload::Type::kFileContents:
@@ -195,7 +196,7 @@ void TransportCurl::Fetch(const std::string& url,
                       CURLFORM_BUFFERLENGTH, file.data.length(),
                       CURLFORM_CONTENTTYPE, content_type, CURLFORM_END);*/
           /* Add a part */
-          curl_mimepart* part = curl_mime_addpart(multipart_);
+          part = curl_mime_addpart(multipart_);
           curl_mime_name(part, name.c_str());
           /* Memory source: */
           curl_mime_data(part, file.data.c_str(), file.data.length());
@@ -212,7 +213,7 @@ void TransportCurl::Fetch(const std::string& url,
                       CURLFORM_FILE, file.data.c_str(),
                       CURLFORM_CONTENTTYPE, content_type, CURLFORM_END);*/
           /* Add a part */
-          curl_mimepart* part = curl_mime_addpart(multipart_);
+          part = curl_mime_addpart(multipart_);
           curl_mime_name(part, name.c_str());
           /* File source: */
           curl_mime_filedata(part, file.data.c_str());
@@ -226,7 +227,6 @@ void TransportCurl::Fetch(const std::string& url,
     /* Auto free the resources occupied by `form_parts`. */
     /*std::unique_ptr<curl_httppost, void (*)(curl_httppost*)>
        form_parts_deleter( form_parts, [](curl_httppost* d) {
-          /* https://curl.se/libcurl/c/curl_formfree.html *
           curl_formfree(d);
         });*/
 

--- a/src/http/transport-curl.cc
+++ b/src/http/transport-curl.cc
@@ -201,8 +201,7 @@ void TransportCurl::Fetch(const std::string& url,
           /* Memory source: */
           curl_mime_data(part, file.data.c_str(), file.data.length());
           curl_mime_filename(part, file.path.c_str());
-          curl_mime_type(part,
-                         content_type);
+          curl_mime_type(part, content_type);
           break;
         case FileUpload::Type::kFileName:
           /* https://curl.se/libcurl/c/curl_formadd.html


### PR DESCRIPTION
Migrating away from the deprecated `curl_formadd` to the new libcurl MIME API.

@vasild Could you please review this PR? It's a important one (I kept the old code for your reference, I will remove this before merge this PR)/

See "Http posting" heading: https://curl.se/libcurl/c/libcurl-tutorial.html#HTTP

Resolves: https://gitlab.melroy.org/libreweb/libreweb-browser/-/jobs/15893#L130